### PR TITLE
Fixed call to the extensions admin controller in the manage screen

### DIFF
--- a/src/Http/Controllers/Admin/ExtensionController.php
+++ b/src/Http/Controllers/Admin/ExtensionController.php
@@ -73,7 +73,7 @@ class ExtensionController extends Controller
             abort(404, 'No extension was found');
         }
 
-        $call = $this->callExtensionMethod('AdminController', 'index', $extension);
+        $call = $this->callExtensionMethod('Http\Controllers\AdminController', 'index', $extension);
 
         if($call !== false)
             return $call;


### PR DESCRIPTION
Getting a `FatalThrowableError` whenever trying to manage my extension.
```php
$call = $this->callExtensionMethod('AdminController', 'index', $extension);
```
To
```php
$call = $this->callExtensionMethod('Http\Controllers\AdminController', 'index', $extension);
```
Fixed it